### PR TITLE
Remove Support Tech and Lead Product Designer openings.

### DIFF
--- a/jobs.md
+++ b/jobs.md
@@ -8,77 +8,10 @@ title: Job listings &mdash; Engineering and Marketing &amp; Revenue Growth Jobs 
   <h2>npm is hiring</h2>
 </hgroup>
 
-We are currently accepting applications for two [support techs](#support-tech) and a [lead product designer](#lead-product-designer). Even if that's not what you have in mind, if you would like to work with us and have skills you think would be helpful, please send an email with evidence of your experience (like your resume, or links to LinkedIn/GitHub/wherever) to [jobs@npmjs.com](mailto:jobs@npmjs.com).
+We are not currently hiring for any specific positions. If you would like to work with us and have skills you think would be helpful, please send an email with evidence of your experience (like your resume, or links to LinkedIn/GitHub/wherever) to [jobs@npmjs.com](mailto:jobs@npmjs.com).
 
 We’d like to hear from you.
 
-* [Support Tech](#support-tech)
-* [Lead Product Designer](#lead-product-designer)
-
-## Support Tech
-
-npm has more than 3 million users worldwide and that number is growing
-fast. Their use-cases are incredibly diverse: from systems
-administrators writing automation tools, to hobbyists building robots,
-to back-end engineers building mobile app APIs, to millions of
-front-end developers.
-
-Our mission at npm is to reduce developer friction.  We do it by
-building tools that make JavaScript developers' lives easier, by
-maintaining a registry with better than 99.999% uptime, and by
-answering each of the tweets, emails, and GitHub issues that our users
-send us every day.
-
-npm has been successful because we care about our users.  "npm loves
-you" is not just marketing; it's a core company value.  Users
-frequently report our responsive and friendly support team as a key
-reason why they love our products.
-
-### is this you?
-
-The right people for this job combine empathy and communication skills
-with a passion for solving technical problems.  Experience with Open
-Source and customer service are beneficial, but not required.
-
-Your job will be to serve as the first line of support, fielding
-common questions, building up FAQs, on-boarding new customers, and
-solving the unusual or complicated cases yourself, with the help of
-every member of the engineering team.
-
-By directly helping our users and customers, and interacting with
-every member of the team, you'll gain the kind of cross-company
-insight that is so valuable to a career in technology.
-
-Sometimes, this job is hard, because people are not always nice.  You'll be helping to keep the npm community a safe and friendly place, with the technical and emotional support of the entire company, and the gratitude of countless developers who participate in the npm ecosystem.
-
-We're opening two roles for new Support Techs.  You'll
-be a full employee with all benefits, including competitive salary and
-stock options.  We are not accepting remote candidates for this role.
-
-
-## Lead Product Designer
-
-npm is the largest module repository in the world, built to help developers connect and share JavaScript code. Since its inception in 2009, our passionate community has shared more than 230,000 modules, and in the last week alone, they’ve downloaded these almost a billion times.
-
-We also are a key part of the inner-source movement, which takes lessons learned in developing open source software and applies them to help companies develop software internally.
-
-### about this role
-
-We are incredibly proud of our community and we’re looking for a lead product designer who can help us understand and better meet their needs.
-
-As Lead Product Designer, you will help us understand the diverse needs of our different user types — from the hack school grad dabbling in his first open source project to the seasoned programmer looking for the right tools for her company. You will then advocate for our users while collaborating with our engineering, marketing, product, and leadership teams.
-
-Your role will range from product thinking, to interaction, to pixel-perfect detailed mockups.
-
-* You are comfortable working openly, sharing works in progress, and explaining your thought process.
-* You build expressive prototypes, whether they are in Axure, InVision, or HTML/CSS/JS. Your choice of tools doesn’t matter. We care that you are able to communicate detail in transitions, animations, and complex interactions.
-* You will expand our existing brand language and show us how to use it to create compelling components and user flows.
-* You have experience presenting your work to a team in a crit-based environment, and the humility to look objectively at ways to improve it.
-* You are comfortable running user tests to validate design decisions. Whether you use online surveys, site data, or qualitative interviews, you can back up complex decisions that need the additional user insight.
-* You don’t have to be a programmer, but you love designing for developers and could get into CLI workflows.
-* You appreciate our slightly quirky aesthetic and can see ways to run with it.
-
-This position will be based in our offices in Oakland, CA, and we are not looking for remote candidates for this position.
 
 ## About npm, Inc.
 


### PR DESCRIPTION
Update to jobs page to reflect no open positions. 

I left the "npm is hiring" heading, as it appears to have been left in the past. I can remove is desired. 